### PR TITLE
Change serialization format from Marshal to JSON

### DIFF
--- a/lib/rapnd.rb
+++ b/lib/rapnd.rb
@@ -7,7 +7,7 @@ module Rapnd
   extend self
   
   def queue(queue_name, message)
-    self.redis.lpush(queue_name, Marshal.dump(message))
+    self.redis.lpush(queue_name, message.to_json)
   end
   
   def redis

--- a/lib/rapnd/daemon.rb
+++ b/lib/rapnd/daemon.rb
@@ -54,7 +54,7 @@ module Rapnd
         begin
           message = @redis.blpop(self.queue, 1)
           if message
-            notification = Rapnd::Notification.new(Marshal.load(message.last))
+            notification = Rapnd::Notification.new(JSON(message.last).symbolize_keys)
             self.connect! unless self.connected
             @logger.info "Sending #{notification.device_token}: #{notification.json_payload}"
             self.apple.write(notification.to_bytes)

--- a/spec/rapnd_spec.rb
+++ b/spec/rapnd_spec.rb
@@ -14,7 +14,7 @@ describe "Rapnd" do
     Rapnd.queue('test_queue', {:alert => 'Hi!'})
     
     @redis.llen('test_queue').should == 1
-    Marshal.load(@redis.lpop('test_queue')).should == {:alert => 'Hi!'}
+    JSON(@redis.lpop('test_queue')).symbolize_keys.should == {:alert => 'Hi!'}
   end
   
   it 'gets a redis connection' do


### PR DESCRIPTION
I've changed notification serialization to JSON format, because it is more universal and more cross-platform. In my use case I've needed to push notifications to Redis queue from node.js (I use it with socket.io for realtime gameplay communication)

What do you think?
